### PR TITLE
fix: #4

### DIFF
--- a/inst/template/R/assets.R
+++ b/inst/template/R/assets.R
@@ -26,6 +26,10 @@ serveAssets <- function(modules = NULL){
 		recursive = TRUE,
 		pattern = ".css$"
 	)
+
+  # exclude specifically html/R.css from a built package
+  # solves https://github.com/devOpifex/leprechaun/issues/4
+  css <- css[css != "html/R.css"]
 	
 	# so dependency processes correctly
 	names(css) <- rep("file", length(css))


### PR DESCRIPTION
Closes #4 

- exclude html/R.css specifically from the listed system.files of a
built package
- this is included in all packages for docs (I believe)

Attached screenshots of issue listed behaviour 1 (left) and behaviour 2 (right) after fix

![issue4](https://user-images.githubusercontent.com/22748393/163258858-fd51a407-6791-420e-a977-f1f1944bceef.png)
