### PR TITLE
Fix typo

### DIFF
--- a/docs/guide/use.md
+++ b/docs/guide/use.md
@@ -145,7 +145,7 @@ Imports:
 
 - [htmltools](https://github.com/rstudio/htmltools)
 
-## Enpoints
+## Endpoints
 
 There is also a set of functions to help set up 
 session-dependent endpoints.


### PR DESCRIPTION
Fixes a typo "En[d]points" in the documentation